### PR TITLE
Making table's caption optional

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,7 +3,7 @@
     <VueTablePro
         :columns="columns"
         :rows="rows"
-        :title="title"
+        :tableCaption="tableCaption"
         :pagination="pagination"
         :search="search"
         :sortableColumns="sortableColumns"
@@ -47,18 +47,18 @@ export default {
           'car_seats': 'Seats'
         }
       },
-      rows: data,
-      title: 'Cars List',
       pagination: {
         perPage: 15,
         size: 6,
         arrows: true
       },
+      rows: data,
       search: {
         placeholder: 'Type your search',
         className: 'vuetable__search-input'
       },
-      sortableColumns: true
+      sortableColumns: true,
+      tableCaption: 'Cars List'
     }
   }
 }

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -8,7 +8,7 @@
     />
 
     <table>
-      <caption v-show="tableCaption">{{ tableCaption }}</caption>
+      <caption v-if="tableCaption">{{ tableCaption }}</caption>
       <thead v-if="tableHeader">
       <tr>
         <th

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -8,7 +8,7 @@
     />
 
     <table>
-      <caption>{{ tableTitle }}</caption>
+      <caption v-show="tableCaption">{{ tableCaption }}</caption>
       <thead v-if="tableHeader">
       <tr>
         <th
@@ -97,9 +97,9 @@ export default {
       type: Boolean,
       default: true
     },
-    tableTitle: {
+    tableCaption: {
       type: String,
-      default: 'Features Title'
+      default: null
     },
     search: {
       type: Object,
@@ -197,15 +197,15 @@ export default {
         let customColumns = {}
         for (const column in this.columns) {
           if (this.columns.hasOwnProperty(column) && this.expandable.withColumns.includes(column)) {
-            const element = { [column]: this.columns[column] }
-            customColumns = { ...customColumns, ...element }
+            const element = {[column]: this.columns[column]}
+            customColumns = {...customColumns, ...element}
           }
         }
         this.expandableFields = customColumns
       }
 
       if (expandAttachedFields) {
-        this.expandableFields = { ...this.expandableFields, ...this.expandable.attachFields }
+        this.expandableFields = {...this.expandableFields, ...this.expandable.attachFields}
       }
     },
     _toggleExpandable (index) {


### PR DESCRIPTION
No new prop needed. The prop's default was changed to null. If no table caption is provided, it will not be rendered. Also, a little refactor was made: tableTitle is now tableCaption.