### PR TITLE
Chore/remove style dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "lodash.debounce": "^4.0.8",
-    "vue": "^2.5.17"
+    "vue": "^2.5.20"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^3.0.1",
@@ -34,7 +34,7 @@
     "jest-serializer-vue": "^2.0.2",
     "node-sass": "^4.9.0",
     "sass-loader": "^7.0.1",
-    "vue-template-compiler": "^2.5.17"
+    "vue-template-compiler": "^2.5.20"
   },
   "eslintConfig": {
     "root": true,

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1,133 +1,232 @@
-.container {
-    width: 80%;
-    margin: auto;
+/*== Demo styles
+ */
+#vtp-demo {
+  font-family: 'Avenir', Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-align: center;
+  color: #2c3e50;
+  margin-top: 60px;
 }
 
-table {
-    width: 100%;
-    margin: 0 auto;
-    /* The main benefit of table-layout: fixed; is that the table renders much faster. */
-    table-layout: fixed;
+#vtp-demo table {
+  width: 100%;
+  margin: 0 auto;
+  /* The main benefit of table-layout: fixed; is that the table renders much faster. */
+  table-layout: fixed;
 }
 
-caption {
-    text-align: center;
-    background-color: #f1f1f1;
-    font-weight: 700;
-    padding: 10px;
+#vtp-demo caption {
+  text-align: center;
+  background-color: #f1f1f1;
+  font-weight: 700;
+  padding: 10px;
 }
 
-th {
-    background-color: #f2f2f2;
-    text-align: left;
-    padding: 10px;
+#vtp-demo th {
+  background-color: #f2f2f2;
+  text-align: left;
+  padding: 10px;
 }
 
-td {
-    background-color: #f8f8f8;
-    text-align: left;
-    padding: 10px;
+#vtp-demo td {
+  background-color: #f8f8f8;
+  text-align: left;
+  padding: 10px;
+}
+
+.vtp-container {
+  width: 80%;
+  margin: auto;
 }
 
 /*== Search input
  */
-.vuetable__search-input {
-    width: 100%;
-    height: 3em;
-    margin-bottom: 30px;
-    padding: 4px 15px;
-    box-sizing: border-box;
+.vuetablepro__search-input {
+  width: 100%;
+  height: 3em;
+  margin-bottom: 30px;
+  padding: 4px 15px;
+  box-sizing: border-box;
 }
 
 /*== Expandable Rows
  */
-.vuetable__expandable-header {
-    width: 30px;
+.vuetablepro__expandable-header {
+  width: 30px;
 }
 
-.vuetable__expandable-toggler {
-    position: relative;
-    cursor: pointer;
-    user-select: none;
+.vuetablepro__expandable-toggler {
+  position: relative;
+  cursor: pointer;
+  user-select: none;
 }
 
-.vuetable__expandable-toggler::before {
-    content: '+';
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
+.vuetablepro__expandable-toggler::before {
+  content: '+';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
 
-    width: 20px;
-    height: 20px;
-    margin: auto;
+  width: 20px;
+  height: 20px;
+  margin: auto;
 
-    font-size: 16px;
-    font-weight: 600;
-    line-height: 20px;
-    text-align: center;
-    color: #66757F;
-    background-color: #E1E8ED;
-    border-radius: 100%;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 20px;
+  text-align: center;
+  color: #66757F;
+  background-color: #E1E8ED;
+  border-radius: 100%;
 }
 
-.vuetable__expandable-toggler:hover::before {
-    background-color: #CCD6DD;
+.vuetablepro__expandable-toggler:hover::before {
+  background-color: #CCD6DD;
 }
 
-.vuetable__expandable-toggler.is-active::before {
-    content: '-';
-    background-color: #607D8B;
-    color: #F5F8FA;
+.vuetablepro__expandable-toggler.is-active::before {
+  content: '-';
+  background-color: #607D8B;
+  color: #F5F8FA;
 }
 
-.vuetable__expandable-panel {
-    background-color: #F5F8FA;
+.vuetablepro__expandable-panel {
+  background-color: #F5F8FA;
 }
 
-.vuetable__expandable-list {
-    display: flex;
-    flex-flow: row wrap;
-    padding: 20px 40px;
+.vuetablepro__expandable-list {
+  display: flex;
+  flex-flow: row wrap;
+  padding: 20px 40px;
 }
 
-.vuetable__expandable-item {
-    flex: 1 0 25%;
+.vuetablepro__expandable-item {
+  flex: 1 0 25%;
 }
 
-.vuetable__expandable-item:nth-child(n+5) {
-    margin-top: 30px;
+.vuetablepro__expandable-item:nth-child(n+5) {
+  margin-top: 30px;
 }
 
-.vuetable__expandable-label {
-    font-size: 12px;
-    letter-spacing: 0.6px;
-    text-transform: uppercase;
-    color: #66757F;
+.vuetablepro__expandable-label {
+  font-size: 12px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: #66757F;
 }
 
-.vuetable__expandable-value {
-    display: block;
-    margin-top: 3px;
-    font-size: 18px;
-    font-weight: 600;
-    line-height: 24px;
-    letter-spacing: 0.2px;
-    text-transform: capitalize;
+.vuetablepro__expandable-value {
+  display: block;
+  margin-top: 3px;
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 24px;
+  letter-spacing: 0.2px;
+  text-transform: capitalize;
 }
 
 /*== Sortable columns
  */
-.vuetable__sortable-state::after {
-    content: '';
-    display: inline-block;
+.vuetablepro__sortable-state::after {
+  content: '';
+  display: inline-block;
 }
 
-.vuetable__sortable-state--asc::after {
-    content: '\2191';
+.vuetablepro__sortable-state--asc::after {
+  content: '\2191';
 }
 
-.vuetable__sortable-state--desc::after {
-    content: '\2193';
+.vuetablepro__sortable-state--desc::after {
+  content: '\2193';
+}
+
+/*== Pagination
+ */
+.vuetablepro__pagination {
+  margin: 20px auto;
+  user-select: none;
+}
+
+.vuetablepro__pagination-page {
+  display: inline-block;
+  width: 40px;
+  height: 40px;
+  margin: 0 10px;
+  background-color: #E1E8ED;
+  font-size: 17px;
+  line-height: 40px;
+  color: #66757F;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+  box-shadow: 0 0px 1px rgba(0, 0, 0, .4);
+}
+
+.vuetablepro__pagination-page:not(.vuetablepro__pagination-page--current):hover {
+  background-color: #CCD6DD;
+}
+
+.vuetablepro__pagination-page--current {
+  background-color: #607D8B;
+  color: #F5F8FA;
+}
+
+.vuetablepro__pagination-ellipsis {
+  display: inline-block;
+  height: 40px;
+  font-size: 22px;
+  line-height: 27px;
+  letter-spacing: 1px;
+  vertical-align: top;
+  color: #66757F;
+}
+
+.vuetablepro__pagination-arrow {
+  position: relative;
+  display: inline-block;
+  vertical-align: top;
+  width: 40px;
+  height: 40px;
+  margin: 0 10px;
+  background-color: #e1e8ed;
+  font-size: 17px;
+  line-height: 40px;
+  color: #66757F;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+  box-shadow: 0 0px 1px rgba(0, 0, 0, .4);
+}
+
+.vuetablepro__pagination-arrow::before {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 10px;
+  height: 10px;
+  margin: auto;
+  border: solid #607d8b;
+  border-width: 0 2px 2px 0;
+  content: '';
+}
+
+.vuetablepro__pagination-arrow:hover {
+  background-color: #607D8B;
+}
+
+.vuetablepro__pagination-arrow:hover::before {
+  border-color: #F5F8FA;
+}
+
+.vuetablepro__pagination-arrow--previous::before {
+  left: 17px;
+  transform: rotate(135deg);
+}
+
+.vuetablepro__pagination-arrow--next::before {
+  left: 11px;
+  transform: rotate(-45deg);
 }

--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" type="text/css" href="css/styles.css">
   </head>
   <body>
-    <div class="container">
+    <div class="vtp-container">
       <noscript>
         <strong>We're sorry but vue-table-pro doesn't work properly without JavaScript enabled. Please enable it to
           continue.</strong>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="vuetablepro">
+  <div id="vtp-demo">
     <VueTablePro
         :columns="columns"
         :rows="rows"
@@ -24,7 +24,7 @@ import VueTablePro from './components/Table.vue'
 import data from './data/cars'
 
 export default {
-  name: 'app',
+  name: 'vtp-demo',
   components: {
     VueTablePro
   },
@@ -55,7 +55,7 @@ export default {
       rows: data,
       search: {
         placeholder: 'Type your search',
-        className: 'vuetable__search-input'
+        className: 'vuetablepro__search-input'
       },
       sortableColumns: true,
       tableCaption: 'Cars List'
@@ -63,14 +63,3 @@ export default {
   }
 }
 </script>
-
-<style lang="scss">
-#app {
-  font-family: 'Avenir', Helvetica, Arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-align: center;
-  color: #2c3e50;
-  margin-top: 60px;
-}
-</style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="app">
+  <div id="vuetablepro">
     <VueTablePro
         :columns="columns"
         :rows="rows"
@@ -9,8 +9,8 @@
         :sortableColumns="sortableColumns"
         :expandable="expandable"
     >
-      <a slot-scope="extraCol" slot="edit_row">Edit</a>
-      <a slot-scope="extraCol" slot="delete_row">Delete</a>
+      <a slot="edit_row">Edit</a>
+      <a slot="delete_row">Delete</a>
 
       <div slot="search_empty_results">
         <p>No results found.</p>

--- a/src/components/Features/Pagination.vue
+++ b/src/components/Features/Pagination.vue
@@ -2,41 +2,41 @@
   <div
     v-if="hasTableData"
     v-show="isNecessary"
-    class="vuetable__pagination">
+    class="vuetablepro__pagination">
 
     <button
       v-if="arrows"
       v-show="hasMoreUntilFirst"
-      class="vuetable__pagination-arrow vuetable__pagination-arrow--previous"
+      class="vuetablepro__pagination-arrow vuetablepro__pagination-arrow--previous"
       @click="_updatePagination(currentPage - 1)"/>
 
     <button
       :class="_isCurrentPage(first)"
-      class="vuetable__pagination-page"
+      class="vuetablepro__pagination-page"
       @click="_updatePagination(first)">
       {{ first }}
     </button>
 
     <span
       v-show="hasMoreUntilFirst"
-      class="vuetable__pagination-ellipsis">...</span>
+      class="vuetablepro__pagination-ellipsis">...</span>
 
     <button
       v-for="page in navigationPages"
       :class="_isCurrentPage(page)"
       :key="page"
-      class="vuetable__pagination-page"
+      class="vuetablepro__pagination-page"
       @click="_updatePagination(page)">
       {{ page }}
     </button>
 
     <span
       v-show="hasMoreUntilLast"
-      class="vuetable__pagination-ellipsis">...</span>
+      class="vuetablepro__pagination-ellipsis">...</span>
 
     <button
       :class="_isCurrentPage(last)"
-      class="vuetable__pagination-page"
+      class="vuetablepro__pagination-page"
       @click="_updatePagination(last)">
       {{ last }}
     </button>
@@ -44,7 +44,7 @@
     <button
       v-if="arrows"
       v-show="hasMoreUntilLast"
-      class="vuetable__pagination-arrow vuetable__pagination-arrow--next"
+      class="vuetablepro__pagination-arrow vuetablepro__pagination-arrow--next"
       @click="_updatePagination(currentPage + 1)"/>
   </div>
 </template>
@@ -129,7 +129,7 @@ export default {
       }
     },
     _isCurrentPage (page) {
-      return page === this.currentPage ? 'vuetable__pagination-page--current' : ''
+      return page === this.currentPage ? 'vuetablepro__pagination-page--current' : ''
     },
     _checkIfHasMoreUntilFirst () {
       if (this.isFirstItemOfNav && this.currentPage <= this.pageSize) {
@@ -260,91 +260,3 @@ export default {
   }
 }
 </script>
-
-<style lang="scss" scoped>
-.vuetable__pagination {
-  margin: 20px auto;
-  user-select: none;
-}
-
-.vuetable__pagination-page {
-  display: inline-block;
-  width: 40px;
-  height: 40px;
-  margin: 0 10px;
-  background-color: #E1E8ED;
-  font-size: 17px;
-  line-height: 40px;
-  color: #66757F;
-  border: none;
-  border-radius: 3px;
-  cursor: pointer;
-  box-shadow: 0 0px 1px rgba(0, 0, 0, .4);
-}
-
-.vuetable__pagination-page:not(.vuetable__pagination-page--current):hover {
-  background-color: #CCD6DD;
-}
-
-.vuetable__pagination-page--current {
-  background-color: #607D8B;
-  color: #F5F8FA;
-}
-
-.vuetable__pagination-ellipsis {
-  display: inline-block;
-  height: 40px;
-  font-size: 22px;
-  line-height: 27px;
-  letter-spacing: 1px;
-  vertical-align: top;
-  color: #66757F;
-}
-
-.vuetable__pagination-arrow {
-  position: relative;
-  display: inline-block;
-  vertical-align: top;
-  width: 40px;
-  height: 40px;
-  margin: 0 10px;
-  background-color: #e1e8ed;
-  font-size: 17px;
-  line-height: 40px;
-  color: #66757F;
-  border: none;
-  border-radius: 3px;
-  cursor: pointer;
-  box-shadow: 0 0px 1px rgba(0, 0, 0, .4);
-
-  &::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    width: 10px;
-    height: 10px;
-    margin: auto;
-    border: solid #607d8b;
-    border-width: 0 2px 2px 0;
-    content: '';
-  }
-
-  &:hover {
-    background-color: #607D8B;
-
-    &::before {
-      border-color: #F5F8FA;
-    }
-  }
-}
-
-.vuetable__pagination-arrow--previous::before {
-  left: 17px;
-  transform: rotate(135deg);
-}
-
-.vuetable__pagination-arrow--next::before {
-  left: 11px;
-  transform: rotate(-45deg);
-}
-</style>

--- a/src/components/Features/SortButton.vue
+++ b/src/components/Features/SortButton.vue
@@ -95,7 +95,7 @@ export default {
   },
   computed: {
     className () {
-      return 'vuetable__sortable-state--' + this._getCurrentState()
+      return 'vuetablepro__sortable-state--' + this._getCurrentState()
     }
   },
   created () {

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="vuetable" v-if="rows">
+  <div class="vuetablepro" v-if="rows">
     <Search
         v-if="search"
         :className="search.className"
@@ -13,7 +13,7 @@
       <tr>
         <th
             v-if="expandable"
-            class="vuetable__expandable-header">
+            class="vuetablepro__expandable-header">
         </th>
         <th v-for="(value, key, index) in columns" :key="index">
           <SortButton
@@ -37,7 +37,7 @@
               v-if="expandable"
               @click="_toggleExpandable(rowIndex)"
               :class="{ 'is-active': _isExpanded(rowIndex) }"
-              class="vuetable__expandable-toggler">
+              class="vuetablepro__expandable-toggler">
           </td>
           <td v-for="colKey in _getDisplayableKeys(columns)" :key="colKey">
             <slot :name="colKey">{{ row[colKey] }}</slot>
@@ -46,15 +46,15 @@
         <tr
             v-show="_isExpanded(rowIndex)"
             :key="`expandable-${rowIndex}`">
-          <td :colspan="tableHeadersLength" class="vuetable__expandable-panel">
-            <div class="vuetable__expandable-list">
+          <td :colspan="tableHeadersLength" class="vuetablepro__expandable-panel">
+            <div class="vuetablepro__expandable-list">
               <div
                   v-for="(colKey, colField) in expandableFields"
                   :key="colKey"
-                  class="vuetable__expandable-item">
+                  class="vuetablepro__expandable-item">
                 <slot :name="colKey">
-                  <span class="vuetable__expandable-label">{{ expandableFields[colField] }}</span>
-                  <span class="vuetable__expandable-value">{{ row[colField] }}</span>
+                  <span class="vuetablepro__expandable-label">{{ expandableFields[colField] }}</span>
+                  <span class="vuetablepro__expandable-value">{{ row[colField] }}</span>
                 </slot>
               </div>
             </div>
@@ -237,6 +237,3 @@ export default {
   }
 }
 </script>
-
-<style scoped>
-</style>

--- a/tests/unit/Pagination.spec.js
+++ b/tests/unit/Pagination.spec.js
@@ -27,7 +27,7 @@ describe('Pagination', () => {
     })
 
     it('renders the root element', () => {
-      expect(wrapper.classes()).toContain('vuetable__pagination')
+      expect(wrapper.classes()).toContain('vuetablepro__pagination')
     })
 
     describe('With insufficient rows to paginate', () => {
@@ -57,13 +57,13 @@ describe('Pagination', () => {
       })
 
       it('has two pages', () => {
-        expect(wrapper.findAll('.vuetable__pagination-page').length).toBe(2)
+        expect(wrapper.findAll('.vuetablepro__pagination-page').length).toBe(2)
       })
 
       it('sets the second page as current upon click', () => {
-        const secondPage = wrapper.findAll('.vuetable__pagination-page').at(1)
+        const secondPage = wrapper.findAll('.vuetablepro__pagination-page').at(1)
         secondPage.trigger('click')
-        expect(secondPage.classes()).toContain('vuetable__pagination-page--current')
+        expect(secondPage.classes()).toContain('vuetablepro__pagination-page--current')
         expect(wrapper.vm.currentPage).toBe(2)
       })
 
@@ -75,13 +75,13 @@ describe('Pagination', () => {
         })
 
         it('renders both "previous" and "next" arrows', () => {
-          expect(wrapper.find('.vuetable__pagination-arrow--previous').exists()).toBe(true)
-          expect(wrapper.find('.vuetable__pagination-arrow--next').exists()).toBe(true)
+          expect(wrapper.find('.vuetablepro__pagination-arrow--previous').exists()).toBe(true)
+          expect(wrapper.find('.vuetablepro__pagination-arrow--next').exists()).toBe(true)
         })
 
         it('hides both "previous" and "next" arrows', () => {
-          expect(wrapper.find('.vuetable__pagination-arrow--previous').isVisible()).toBe(false)
-          expect(wrapper.find('.vuetable__pagination-arrow--next').isVisible()).toBe(false)
+          expect(wrapper.find('.vuetablepro__pagination-arrow--previous').isVisible()).toBe(false)
+          expect(wrapper.find('.vuetablepro__pagination-arrow--next').isVisible()).toBe(false)
         })
       })
     })
@@ -126,7 +126,7 @@ describe('Pagination', () => {
         })
 
         it('has two pages', () => {
-          expect(wrapper.findAll('.vuetable__pagination-page').length).toBe(2)
+          expect(wrapper.findAll('.vuetablepro__pagination-page').length).toBe(2)
         })
       })
       describe('Size 20', () => {
@@ -137,7 +137,7 @@ describe('Pagination', () => {
         })
 
         it('has two pages', () => {
-          expect(wrapper.findAll('.vuetable__pagination-page').length).toBe(2)
+          expect(wrapper.findAll('.vuetablepro__pagination-page').length).toBe(2)
         })
       })
     })
@@ -172,13 +172,13 @@ describe('Pagination', () => {
       })
 
       it('has 5 pages', () => {
-        expect(wrapper.findAll('.vuetable__pagination-page').length).toBe(5)
+        expect(wrapper.findAll('.vuetablepro__pagination-page').length).toBe(5)
       })
 
       it('sets the last page as current upon click', () => {
-        const lastPage = wrapper.findAll('.vuetable__pagination-page').at(4)
+        const lastPage = wrapper.findAll('.vuetablepro__pagination-page').at(4)
         lastPage.trigger('click')
-        expect(lastPage.classes()).toContain('vuetable__pagination-page--current')
+        expect(lastPage.classes()).toContain('vuetablepro__pagination-page--current')
         expect(wrapper.vm.currentPage).toBe(12)
       })
 
@@ -190,33 +190,33 @@ describe('Pagination', () => {
         })
 
         it('renders both "previous" and "next" arrows', () => {
-          expect(wrapper.find('.vuetable__pagination-arrow--previous').exists()).toBe(true)
-          expect(wrapper.find('.vuetable__pagination-arrow--next').exists()).toBe(true)
+          expect(wrapper.find('.vuetablepro__pagination-arrow--previous').exists()).toBe(true)
+          expect(wrapper.find('.vuetablepro__pagination-arrow--next').exists()).toBe(true)
         })
 
         it('hides "previous" arrow', () => {
-          expect(wrapper.find('.vuetable__pagination-arrow--previous').isVisible()).toBe(false)
+          expect(wrapper.find('.vuetablepro__pagination-arrow--previous').isVisible()).toBe(false)
         })
 
         it('shows "next" arrow', () => {
-          expect(wrapper.find('.vuetable__pagination-arrow--next').isVisible()).toBe(true)
+          expect(wrapper.find('.vuetablepro__pagination-arrow--next').isVisible()).toBe(true)
         })
 
         it('shows "previous" arrow when there\'s more pages until the first', () => {
-          const page = wrapper.findAll('.vuetable__pagination-page').at(3)
+          const page = wrapper.findAll('.vuetablepro__pagination-page').at(3)
           page.trigger('click')
-          expect(wrapper.find('.vuetable__pagination-arrow--previous').isVisible()).toBe(true)
+          expect(wrapper.find('.vuetablepro__pagination-arrow--previous').isVisible()).toBe(true)
         })
 
         it('hides "next" arrow when there\'s no more pages until the last', () => {
-          const page = wrapper.findAll('.vuetable__pagination-page').at(4)
+          const page = wrapper.findAll('.vuetablepro__pagination-page').at(4)
           page.trigger('click')
-          expect(wrapper.find('.vuetable__pagination-arrow--next').isVisible()).toBe(false)
+          expect(wrapper.find('.vuetablepro__pagination-arrow--next').isVisible()).toBe(false)
         })
 
         it('emits pagination when clicking the previous arrow', () => {
-          const page = wrapper.findAll('.vuetable__pagination-page').at(3)
-          const arrow = wrapper.find('.vuetable__pagination-arrow--next')
+          const page = wrapper.findAll('.vuetablepro__pagination-page').at(3)
+          const arrow = wrapper.find('.vuetablepro__pagination-arrow--next')
           page.trigger('click')
           expect(wrapper.emitted().pagination.length).toBe(2)
           arrow.trigger('click')
@@ -224,7 +224,7 @@ describe('Pagination', () => {
         })
 
         it('emits pagination when clicking the next arrow', () => {
-          const arrow = wrapper.find('.vuetable__pagination-arrow--next')
+          const arrow = wrapper.find('.vuetablepro__pagination-arrow--next')
           const currentEmitted = wrapper.emitted().pagination.length
           arrow.trigger('click')
           expect(wrapper.emitted().pagination.length).toBe(currentEmitted + 1)
@@ -244,13 +244,13 @@ describe('Pagination', () => {
       })
 
       it('has 5 pages', () => {
-        expect(wrapper.findAll('.vuetable__pagination-page').length).toBe(5)
+        expect(wrapper.findAll('.vuetablepro__pagination-page').length).toBe(5)
       })
 
       it('sets the last page as current upon click', () => {
-        const lastPage = wrapper.findAll('.vuetable__pagination-page').at(4)
+        const lastPage = wrapper.findAll('.vuetablepro__pagination-page').at(4)
         lastPage.trigger('click')
-        expect(lastPage.classes()).toContain('vuetable__pagination-page--current')
+        expect(lastPage.classes()).toContain('vuetablepro__pagination-page--current')
         expect(wrapper.vm.currentPage).toBe(5)
       })
     })

--- a/tests/unit/Table.spec.js
+++ b/tests/unit/Table.spec.js
@@ -43,25 +43,24 @@ describe('Table', () => {
         expect(wrapper.find('caption').text()).toBe('Cars List')
       })
     })
-    
+
     describe('With expandable', () => {
-      
       it('renders only with withColumns option', () => {
         const wrapper = shallowMount(Table, { propsData: tableProps })
-        wrapper.setProps( { expandable: { withColumns: ['car_brand', 'car_model'] } } )
-        expect(wrapper.html()).toContain('vuetable__expandable-panel')
+        wrapper.setProps({ expandable: { withColumns: ['car_brand', 'car_model'] } })
+        expect(wrapper.html()).toContain('vuetablepro__expandable-panel')
       })
-      
+
       it('renders only with attachFields option', () => {
         const wrapper = shallowMount(Table, { propsData: tableProps })
-        expect(wrapper.html()).toContain('vuetable__expandable-panel')
+        expect(wrapper.html()).toContain('vuetablepro__expandable-panel')
       })
-      
+
       it('expands row when clicked', () => {
         const wrapper = shallowMount(Table, { propsData: tableProps })
-        wrapper.setProps( { expandable: { attachFields: { 'car_fuel': 'Fuel', 'car_color': 'Color' } } } )
-        wrapper.find('.vuetable__expandable-toggler').trigger('click')
-        expect(wrapper.find('.vuetable__expandable-toggler').classes()).toContain('is-active')
+        wrapper.setProps({ expandable: { attachFields: { 'car_fuel': 'Fuel', 'car_color': 'Color' } } })
+        wrapper.find('.vuetablepro__expandable-toggler').trigger('click')
+        expect(wrapper.find('.vuetablepro__expandable-toggler').classes()).toContain('is-active')
       })
     })
   })

--- a/tests/unit/__snapshots__/Table.spec.js.snap
+++ b/tests/unit/__snapshots__/Table.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Table With rows renders correctly 1`] = `
-<div class="vuetable">
+<div class="vuetablepro">
   <!---->
   <table>
     <!---->
@@ -24,8 +24,8 @@ exports[`Table With rows renders correctly 1`] = `
         <td>4</td>
       </tr>
       <tr style="display: none;">
-        <td colspan="0" class="vuetable__expandable-panel">
-          <div class="vuetable__expandable-list"></div>
+        <td colspan="0" class="vuetablepro__expandable-panel">
+          <div class="vuetablepro__expandable-list"></div>
         </td>
       </tr>
       <tr>
@@ -41,8 +41,8 @@ exports[`Table With rows renders correctly 1`] = `
         <td>5</td>
       </tr>
       <tr style="display: none;">
-        <td colspan="0" class="vuetable__expandable-panel">
-          <div class="vuetable__expandable-list"></div>
+        <td colspan="0" class="vuetablepro__expandable-panel">
+          <div class="vuetablepro__expandable-list"></div>
         </td>
       </tr>
     </tbody>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9265,10 +9265,10 @@ vue-style-loader@^4.1.0:
     hash-sum "^1.0.2"
     loader-utils "^1.0.2"
 
-vue-template-compiler@^2.5.17:
-  version "2.5.17"
-  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.5.17.tgz#52a4a078c327deb937482a509ae85c06f346c3cb"
-  integrity sha512-63uI4syCwtGR5IJvZM0LN5tVsahrelomHtCxvRkZPJ/Tf3ADm1U1wG6KWycK3qCfqR+ygM5vewUvmJ0REAYksg==
+vue-template-compiler@^2.5.20:
+  version "2.5.21"
+  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.5.21.tgz#a57ceb903177e8f643560a8d639a0f8db647054a"
+  integrity sha512-Vmk5Cv7UcmI99B9nXJEkaK262IQNnHp5rJYo+EwYpe2epTAXqcVyExhV6pk8jTkxQK2vRc8v8KmZBAwdmUZvvw==
   dependencies:
     de-indent "^1.0.2"
     he "^1.1.0"
@@ -9278,10 +9278,10 @@ vue-template-es2015-compiler@^1.6.0:
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz#dc42697133302ce3017524356a6c61b7b69b4a18"
   integrity sha512-x3LV3wdmmERhVCYy3quqA57NJW7F3i6faas++pJQWtknWT+n7k30F4TVdHvCLn48peTJFRvCpxs3UuFPqgeELg==
 
-vue@^2.5.17:
-  version "2.5.17"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-2.5.17.tgz#0f8789ad718be68ca1872629832ed533589c6ada"
-  integrity sha512-mFbcWoDIJi0w0Za4emyLiW72Jae0yjANHbCVquMKijcavBGypqlF7zHRgMa5k4sesdv7hv2rB4JPdZfR+TPfhQ==
+vue@^2.5.20:
+  version "2.5.21"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.5.21.tgz#3d33dcd03bb813912ce894a8303ab553699c4a85"
+  integrity sha512-Aejvyyfhn0zjVeLvXd70h4hrE4zZDx1wfZqia6ekkobLmUZ+vNFQer53B4fu0EjWBSiqApxPejzkO1Znt3joxQ==
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Updated the version of Vue that fixes the warning about duplicated slots.

Removed all styles from the plugin components into the separate stylesheet `styles.css` and renamed the base classname from `vuetable` into `vuetablepro`